### PR TITLE
renaming leftside to lhs (left-hand side), similarly rightside

### DIFF
--- a/mvdXML1.2/grammar/ANTLR/mvdXMLv1_2.g
+++ b/mvdXML1.2/grammar/ANTLR/mvdXMLv1_2.g
@@ -8,10 +8,10 @@ expression
 boolean_expression
     :    boolean_term (logical_interconnection boolean_term)*  ;
 boolean_term
-    :    NOT? ( ( leftside operator rightside )  |  ( LPAREN boolean_expression RPAREN ) );
-leftside
+    :    NOT? ( ( lhs operator rhs )  |  ( LPAREN boolean_expression RPAREN ) );
+lhs
     :    parameter_metric | metric;
-rightside
+rhs
     :    parameter_metric | value;
 parameter_metric
     :    parameter (metric)?;


### PR DESCRIPTION
Proposal to rename

- leftside to `lhs` (more standardized or *left-hand side*  of an equation)
- -similarly for rightside to `rhs`