### PR TITLE
restricting SELF[TYPE] to a special token

### DIFF
--- a/mvdXML1.2/grammar/ANTLR/mvdXMLv1_2.g
+++ b/mvdXML1.2/grammar/ANTLR/mvdXMLv1_2.g
@@ -10,13 +10,13 @@ boolean_expression
 boolean_term
     :    NOT? ( ( leftside operator rightside )  |  ( LPAREN boolean_expression RPAREN ) );
 leftside
-    :    parameter_metric | metric;
+    :    parameter_metric | metric | SELF_TYPE ;
 rightside
     :    parameter_metric | value;
 parameter_metric
     :    parameter (metric)?;
 parameter 
-    :    simple_id | SELF ;
+    :    simple_id ;
 simple_id 
     :    letter ( letter | ZERO | DIGITNONZERO | '_' )* ;
 metric
@@ -97,8 +97,8 @@ UNKNOWN
     :    'UNKNOWN' | 'unknown' ;
 REG
     :    'reg';
-SELF
-    :    ( 'S' | 's' ) ( 'ELF' | 'elf' ) ;
+SELF_TYPE
+    :    'SELF_TYPE' | 'self_type' ;
 EXP
     :    'e' | 'E';
 PLUS


### PR DESCRIPTION
### Issue at hand

I have a few concerns about the newly introduced `SELF` token.

- It is available for leftside as well as rightside through the `parameter` token. 
- It is possible to combine it with any `metric`.

This would in general allow for parameter strings like

> SELF[Value] = SELF[Unique]

which in my view doesn't make any sense. 

### Proposal

In this PR, I introduced a special token `SELF_TYPE` (naming discussable) that should support *only* the intended use, i.e. being only on the leftside of the `boolean_term`, and only combined with the `[Type]` metric. 

This would change example 7.2.3 from

> `SELF[Type]!=IfcAnnonation`

to

> `SELF_TYPE!=IfcAnnonation`

The documentation would probably need some minor updating if this is agreed upon.