### PR TITLE
Proposed fix for Unit definition

### DIFF
--- a/mvdXML1.2/xsd/mvdXML_V1-2_Draft9.xsd
+++ b/mvdXML1.2/xsd/mvdXML_V1-2_Draft9.xsd
@@ -162,7 +162,13 @@
 							</xs:annotation>
 							<xs:complexType>
 								<xs:sequence>
-									<xs:group ref="ifc:IfcUnit" maxOccurs="unbounded"/>
+									<xs:element name="Unit" type="ifc:IfcUnit" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>
+												A Unit element of type IfcUnit from the IFC4 specification.
+											</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>


### PR DESCRIPTION
Fixes:
Fixes #9
#22

Changes:
Created a new `Unit` element in units of `type=ifc:IfcUnit`

Attention:
1. I was a bit confused with the existing definition and could not narrow down the intention. It could be that the proposed fix does not address the requirement.
2. Verify by compiling the xsd

